### PR TITLE
Skip unsupported tests for legacy HHVM

### DIFF
--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -367,7 +367,7 @@ class FilterTest extends TestCase
      */
     public function testRemoveThrowsWhenAppendThrowsOnEvent()
     {
-        if (PHP_VERSION < 7) $this->markTestSkipped('Not supported on legacy PHP (engine crashes)');
+        if (PHP_VERSION < 7 || defined('HHVM_VERSION')) $this->markTestSkipped('Not supported on legacy PHP (engine crashes)');
 
         $stream = $this->createStream();
 


### PR DESCRIPTION
Travis automatically skipped this test by running into `if (PHP_VERSION < 7) $this->markTestSkipped('Not supported on legacy PHP (engine crashes)');`
This test fails when using Github actions for some reason so I had to skip it for HHVM explicitly.

Builds on top of #39 