### PR TITLE
chore: add tests for PHP 8.2, fix ci deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.2
           - 8.1
           - 8.0
           - 7.4
@@ -23,7 +24,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -45,7 +46,7 @@ jobs:
     runs-on: ubuntu-18.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30


### PR DESCRIPTION
The tests are failing on my fork.
No-Changes => [** **](https://github.com/Chris53897/stream-filter/actions/runs/5973390338)

The last run on this repo is more than a year old. I guess gitub changes somethig

Should be fixed in an seperated PR in my point of view.